### PR TITLE
deps: update opentelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The scope required for sending metrics is the `Ingest metrics` scope in the
 The `prefix` parameter specifies an optional prefix, which is prepended to each
 metric key, separated by a dot (`<prefix>.<namespace>.<name>`).
 
-#### Default Labels/Dimensions
+#### Default Attributes/Dimensions
 
 The `defaultDimensions` parameter can be used to optionally specify a list of key/value
 pairs, which will be added as additional attributes/dimensions to all data points.

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ const upDownCounter = meter.createUpDownCounter('test_up_down_counter', {
   description: 'Example of a UpDownCounter',
 });
 
-const labels = { pid: process.pid, environment: 'staging' };
+const attributes = { pid: process.pid, environment: 'staging' };
 
 setInterval(() => {
-  requestCounter.bind(labels).add(1);
-  upDownCounter.bind(labels).add(Math.random() > 0.5 ? 1 : -1);
+  requestCounter.bind(attributes).add(1);
+  upDownCounter.bind(attributes).add(Math.random() > 0.5 ? 1 : -1);
 }, 1000);
 ```
 
@@ -137,7 +137,7 @@ metric key, separated by a dot (`<prefix>.<namespace>.<name>`).
 #### Default Labels/Dimensions
 
 The `defaultDimensions` parameter can be used to optionally specify a list of key/value
-pairs, which will be added as additional labels/dimensions to all data points.
+pairs, which will be added as additional attributes/dimensions to all data points.
 
 #### Retries on Connection Failure
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dynatrace/opentelemetry-exporter-metrics",
   "description": "OpenTelemetry metrics exporter for Dynatrace",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Dynatrace",
   "license": "Apache-2",
   "publishConfig": {
@@ -30,19 +30,17 @@
   },
   "homepage": "https://github.com/dynatrace-oss/opentelemetry-metrics-js#readme",
   "dependencies": {
-    "@dynatrace/metric-utils": "^0.1.0",
-    "@opentelemetry/core": "^0.23.0",
-    "@opentelemetry/metrics": "^0.23.0"
+    "@dynatrace/metric-utils": "0.1.0",
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/sdk-metrics-base": "0.27.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "1.0.1"
+    "@opentelemetry/api": "1.0.4"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.0.1",
-    "@opentelemetry/api-metrics": "^0.23.0",
-    "@opentelemetry/core": "^0.23.0",
-    "@opentelemetry/metrics": "^0.23.0",
-    "@opentelemetry/resources": "^0.23.0",
+    "@opentelemetry/api": "^1.0.4",
+    "@opentelemetry/api-metrics": "^0.27.0",
+    "@opentelemetry/resources": "^1.0.1",
     "@types/jest": "^27.0.2",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@opentelemetry/sdk-metrics-base": "0.27.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "1.0.4"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/jest": "^27.0.2",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^16.3.2",
+    "@types/sinon": "^10.0.11",
     "@typescript-eslint/eslint-plugin": "^4.28.3",
     "@typescript-eslint/parser": "^4.28.3",
     "eslint": "^7.30.0",
@@ -54,6 +55,7 @@
     "mock-fs": "^5.0.0",
     "nock": "^13.1.3",
     "rimraf": "^3.0.2",
+    "sinon": "^13.0.1",
     "ts-jest": "^27.0.3",
     "typescript": "^4.3.5"
   },

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -27,10 +27,10 @@ const upDownCounter = meter.createUpDownCounter('test_up_down_counter', {
   description: 'Example of a UpDownCounter',
 });
 
-const labels = { pid: process.pid, environment: 'staging' };
+const attributes = { pid: process.pid, environment: 'staging' };
 
 
 setInterval(() => {
-  requestCounter.bind(labels).add(1);
-  upDownCounter.bind(labels).add(Math.random() > 0.5 ? 1 : -1);
+  requestCounter.bind(attributes).add(1);
+  upDownCounter.bind(attributes).add(Math.random() > 0.5 ? 1 : -1);
 }, 1000);

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
-const { MeterProvider } = require('@opentelemetry/metrics');
+const { MeterProvider } = require('@opentelemetry/sdk-metrics-base');
 const { DynatraceMetricExporter } = require('..');
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)

--- a/src/MetricExporter.ts
+++ b/src/MetricExporter.ts
@@ -16,7 +16,7 @@
 
 import { diag } from "@opentelemetry/api";
 import { ExportResult, ExportResultCode, hrTimeToMilliseconds } from "@opentelemetry/core";
-import { AggregatorKind, MetricExporter, MetricRecord } from "@opentelemetry/metrics";
+import { AggregatorKind, MetricExporter, MetricRecord } from "@opentelemetry/sdk-metrics-base";
 import * as http from "http";
 import * as https from "https";
 import * as url from "url";
@@ -127,7 +127,7 @@ export class DynatraceMetricExporter implements MetricExporter {
 		}
 
 		const dtMetrics = metrics.map((metric) => {
-			const dimensions = Object.entries(metric.labels).map(([key, value]) => ({ key, value }));
+			const dimensions = Object.entries(metric.attributes).map(([key, value]) => ({ key, value }));
 			switch (metric.aggregator.kind) {
 				case AggregatorKind.SUM: {
 					// TODO: when metrics 0.20.0 is released use aggregator.aggregationTemporality

--- a/tests/MetricExporter.spec.ts
+++ b/tests/MetricExporter.spec.ts
@@ -20,6 +20,7 @@ import { MetricKind, MetricRecord, SumAggregator } from "@opentelemetry/sdk-metr
 import { AggregationTemporality, ValueType } from "@opentelemetry/api-metrics";
 import { ExportResult, ExportResultCode } from "@opentelemetry/core";
 import { Resource } from "@opentelemetry/resources";
+import * as sinon from "sinon";
 
 
 describe("MetricExporter", () => {
@@ -87,6 +88,26 @@ describe("MetricExporter.export", () => {
 				expect(scope.pendingMocks()).toHaveLength(0);
 				done();
 			});
+	});
+
+	test("should drop cumulative sums but not delta sums", (done) => {
+		const target_host = "https://example.com:8080";
+		const target_path = "/metrics";
+		const target_url = target_host + target_path;
+		const exporter = new DynatraceMetricExporter({
+			url: target_url
+		});
+
+		const spy = exporter["_sendRequest"] = sinon.stub().callsFake((_, cb: (code: ExportResultCode) => void) => cb(ExportResultCode.SUCCESS));
+
+		exporter.export([
+			getTestMetricRecord("delta_test", 10, { "key": "value" }),
+			getTestMetricRecord("cumulative_test", 10, { "key": "value" }, AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE)
+		], () => {
+			sinon.assert.calledOnce(spy);
+			expect(spy.getCalls()[0].firstArg).toMatch(/^delta_test,key=value count,delta=10 \d{13}$/);
+			done();
+		});
 	});
 
 	describe.each([100, 300, 401, 403, 500])(
@@ -293,7 +314,7 @@ describe("MetricExporter.export", () => {
 			});
 	});
 
-	function getTestMetricRecord(name: string, value: number, attributes: { [key: string]: string }): MetricRecord {
+	function getTestMetricRecord(name: string, value: number, attributes: { [key: string]: string }, temporality = AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA): MetricRecord {
 		const aggregator = new SumAggregator();
 		aggregator.update(value);
 
@@ -307,7 +328,7 @@ describe("MetricExporter.export", () => {
 			},
 			attributes: attributes,
 			aggregator: aggregator,
-			aggregationTemporality: AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA,
+			aggregationTemporality: temporality,
 			resource: Resource.EMPTY,
 			instrumentationLibrary: {
 				name: "my-mock-lib"

--- a/tests/MetricExporter.spec.ts
+++ b/tests/MetricExporter.spec.ts
@@ -16,7 +16,7 @@
 
 import { DynatraceMetricExporter } from "../src";
 import * as nock from "nock";
-import { MetricKind, MetricRecord, SumAggregator } from "@opentelemetry/metrics";
+import { MetricKind, MetricRecord, SumAggregator } from "@opentelemetry/sdk-metrics-base";
 import { AggregationTemporality, ValueType } from "@opentelemetry/api-metrics";
 import { ExportResult, ExportResultCode } from "@opentelemetry/core";
 import { Resource } from "@opentelemetry/resources";
@@ -293,7 +293,7 @@ describe("MetricExporter.export", () => {
 			});
 	});
 
-	function getTestMetricRecord(name: string, value: number, labels: { [key: string]: string }): MetricRecord {
+	function getTestMetricRecord(name: string, value: number, attributes: { [key: string]: string }): MetricRecord {
 		const aggregator = new SumAggregator();
 		aggregator.update(value);
 
@@ -305,7 +305,7 @@ describe("MetricExporter.export", () => {
 				metricKind: MetricKind.UP_DOWN_COUNTER,
 				valueType: ValueType.DOUBLE
 			},
-			labels: labels,
+			attributes: attributes,
 			aggregator: aggregator,
 			aggregationTemporality: AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA,
 			resource: Resource.EMPTY,


### PR DESCRIPTION
Update to the latest released useable metrics dependencies and the latest API. Also pin dependencies and bump version for release.

Resolves #18.