### PR TITLE
Warn on non-finite values

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/dynatrace-oss/opentelemetry-metrics-js#readme",
   "dependencies": {
-    "@dynatrace/metric-utils": "0.1.0",
+    "@dynatrace/metric-utils": "0.1.1",
     "@opentelemetry/core": "1.0.1",
     "@opentelemetry/sdk-metrics-base": "0.27.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dynatrace/opentelemetry-exporter-metrics",
   "description": "OpenTelemetry metrics exporter for Dynatrace",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Dynatrace",
   "license": "Apache-2",
   "publishConfig": {

--- a/src/MetricExporter.ts
+++ b/src/MetricExporter.ts
@@ -136,6 +136,18 @@ export class DynatraceMetricExporter implements MetricExporter {
 						return null;
 					}
 					const data = metric.aggregator.toPoint();
+
+					const valueType = typeof data.value;
+					if (valueType !== "number") {
+						diag.warn(`Metric ${metric.descriptor.name} has invalid data.value type ${valueType}`);
+						return null;
+					}
+
+					if (!isFinite(data.value)) {
+						diag.warn(`Metric ${metric.descriptor.name} has non-finite value`);
+						return null;
+					}
+
 					const normalizedMetric = this._dtMetricFactory
 						.createCounterDelta(
 							metric.descriptor.name,
@@ -175,6 +187,17 @@ export class DynatraceMetricExporter implements MetricExporter {
 				}
 				case AggregatorKind.LAST_VALUE: {
 					const data = metric.aggregator.toPoint();
+					const valueType = typeof data.value;
+					if (valueType !== "number") {
+						diag.warn(`Metric ${metric.descriptor.name} has invalid data.value type ${valueType}`);
+						return null;
+					}
+
+					if (!isFinite(data.value)) {
+						diag.warn(`Metric ${metric.descriptor.name} has non-finite value`);
+						return null;
+					}
+
 					const normalizedMetric = this._dtMetricFactory
 						.createGauge(
 							metric.descriptor.name,


### PR DESCRIPTION
Fixes #20

The user reported that values were dropped without warning. Accepting string values is impossible in most cases as the string values are broken many other places including in the SDK aggregators. When an invalid value is received, log a warning and drop the metric.