### PR TITLE
feat(histogram): use min/max from HistogramDataPoint if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This exporter allows exporting metrics created using the [OpenTelemetry SDK for JavaScript](https://github.com/open-telemetry/opentelemetry-js)
 directly to [Dynatrace](https://www.dynatrace.com).
 
-It was built against OpenTelemetry SDK version `0.29.0`.
+It was built against OpenTelemetry SDK version `0.30.0`.
 
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in
 the [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-metrics).

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "homepage": "https://github.com/dynatrace-oss/opentelemetry-metrics-js#readme",
   "dependencies": {
     "@dynatrace/metric-utils": "^0.2.0",
-    "@opentelemetry/api-metrics": "^0.29.0",
+    "@opentelemetry/api-metrics": "^0.30.0",
     "@opentelemetry/core": "~1.3.0",
     "@opentelemetry/resources": "~1.3.0",
-    "@opentelemetry/sdk-metrics-base": "^0.29.0"
+    "@opentelemetry/sdk-metrics-base": "^0.30.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/src/histogram.ts
+++ b/src/histogram.ts
@@ -22,7 +22,7 @@ export function estimateHistogram(point: DataPoint<Histogram>): SummaryValue {
 		return { count: 0, sum: 0, min: 0, max: 0 };
 	}
 
-	const { min, max } = estimateHistMinMax(point);
+	const { min, max } = getMinMax(point);
 
 	return {
 		count: point.value.count,
@@ -30,6 +30,14 @@ export function estimateHistogram(point: DataPoint<Histogram>): SummaryValue {
 		max,
 		min
 	};
+}
+
+function getMinMax(point: DataPoint<Histogram>): { min: number; max: number } {
+	if (point.value.hasMinMax) {
+		return { min: point.value.min, max: point.value.max };
+	}
+
+	return estimateHistMinMax(point);
 }
 
 // Expect to be called only with points that contain actual data (point.value.count > 0)

--- a/tests/histogram.spec.ts
+++ b/tests/histogram.spec.ts
@@ -73,6 +73,9 @@ describe("estimateHistogram", () => {
 					startTime: [0, 0],
 					value: {
 						sum: testCase.sum,
+						hasMinMax: false,
+						min: Infinity,
+						max: -1,
 						buckets: {
 							boundaries: testCase.boundaries,
 							counts: testCase.counts
@@ -154,6 +157,9 @@ describe("estimateHistogram", () => {
 					endTime: [0, 0],
 					startTime: [0, 0],
 					value: {
+						hasMinMax: false,
+						min: Infinity,
+						max: -1,
 						sum: testCase.sum,
 						buckets: {
 							boundaries: testCase.boundaries,
@@ -167,5 +173,53 @@ describe("estimateHistogram", () => {
 				expect(summary.max).toBeCloseTo(testCase.expectedMax);
 			});
 		}
+	});
+
+	test("should take available min/max values with min/max present", () => {
+		const summary = estimateHistogram({
+			attributes: {},
+			endTime: [0, 0],
+			startTime: [0, 0],
+			value: {
+				hasMinMax: true,
+				min: 9,
+				max: 21,
+				sum: 30,
+				buckets: {
+					boundaries: [10, 20],
+					counts: [0, 2, 0]
+				},
+				count: 2
+			}
+		});
+
+		assert.ok(summary);
+		expect(summary.min).toBeCloseTo(9);
+		expect(summary.max).toBeCloseTo(21);
+	});
+
+	test("should return all 0 on empty histogram", () => {
+		const summary = estimateHistogram({
+			attributes: {},
+			endTime: [0, 0],
+			startTime: [0, 0],
+			value: {
+				hasMinMax: false,
+				min: Infinity,
+				max: -1,
+				sum: 0,
+				buckets: {
+					boundaries: [10, 20],
+					counts: [0, 0, 0]
+				},
+				count: 0
+			}
+		});
+
+		assert.ok(summary);
+		expect(summary.sum).toBe(0);
+		expect(summary.count).toBe(0);
+		expect(summary.min).toBe(0);
+		expect(summary.max).toBe(0);
 	});
 });

--- a/tests/histogram.spec.ts
+++ b/tests/histogram.spec.ts
@@ -175,7 +175,7 @@ describe("estimateHistogram", () => {
 		}
 	});
 
-	test("should take available min/max values with min/max present", () => {
+	test("should take min/max when present", () => {
 		const summary = estimateHistogram({
 			attributes: {},
 			endTime: [0, 0],


### PR DESCRIPTION
This PR updates the histogram-to-summary estimation to use the new histogram min/max fields that were introduced in [0.30.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.30.0) of the OTel JS Metrics SDK. 

Further, it updates the OTel JS Metrics SDK to `0.30.0`.
