### PR TITLE
Update metrics SDK to 0.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This exporter allows exporting metrics created using the [OpenTelemetry SDK for JavaScript](https://github.com/open-telemetry/opentelemetry-js)
 directly to [Dynatrace](https://www.dynatrace.com).
 
-It was built against OpenTelemetry SDK version `0.30.0`.
+It was built against OpenTelemetry SDK version `0.31.0`.
 
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in
 the [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-metrics).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dynatrace/opentelemetry-exporter-metrics",
   "description": "OpenTelemetry metrics exporter for Dynatrace",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Dynatrace",
   "license": "Apache-2",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   "homepage": "https://github.com/dynatrace-oss/opentelemetry-metrics-js#readme",
   "dependencies": {
     "@dynatrace/metric-utils": "^0.2.0",
-    "@opentelemetry/api-metrics": "^0.30.0",
-    "@opentelemetry/core": "~1.4.0",
-    "@opentelemetry/resources": "~1.4.0",
-    "@opentelemetry/sdk-metrics-base": "^0.30.0"
+    "@opentelemetry/api-metrics": "^0.31.0",
+    "@opentelemetry/core": "~1.5.0",
+    "@opentelemetry/resources": "~1.5.0",
+    "@opentelemetry/sdk-metrics-base": "^0.31.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -33,7 +33,10 @@ const requestCounter = meter.createCounter('requests', {
 const upDownCounter = meter.createUpDownCounter('test_up_down_counter', {
   description: 'Example of a UpDownCounter'
 });
-const attributes = { pid: process.pid, environment: 'staging' };
+const attributes = {
+  pid: process.pid.toString(),
+  environment: 'staging'
+};
 
 setInterval(() => {
   requestCounter.add(Math.round(Math.random() * 1000), attributes);

--- a/src/DynatraceMetricExporter.ts
+++ b/src/DynatraceMetricExporter.ts
@@ -340,7 +340,7 @@ function dimensionsFromPoint(point: DataPoint<unknown>): Dimension[] {
 			const type = typeof value;
 			const valid = (type === "string");
 			if (!valid) {
-				diag.warn(`Skipping unsupported dimension with value type '${value}'`);
+				diag.warn(`Skipping unsupported dimension '${entry[0]}' with value type '${type}'`);
 			}
 			return valid;
 		})

--- a/src/DynatraceMetricExporter.ts
+++ b/src/DynatraceMetricExporter.ts
@@ -338,7 +338,7 @@ function dimensionsFromPoint(point: DataPoint<unknown>): Dimension[] {
 		.filter(function(entry): entry is [string, string | number] {
 			const value = entry[1];
 			const type = typeof value;
-			const valid = type === "string" || type === "number" || type === "boolean" || type === "bigint" || type === "symbol";
+			const valid = (type === "string");
 			if (!valid) {
 				diag.warn(`Skipping unsupported dimension with value type '${value}'`);
 			}

--- a/src/histogram.ts
+++ b/src/histogram.ts
@@ -30,6 +30,7 @@ export function estimateHistogram(point: DataPoint<Histogram>): SummaryValue {
 
 function estimateSingleBucketHistogram(point: DataPoint<Histogram>): { min: number; max: number; sum: number } {
 	const sum = point.value.sum ?? 0;
+	// Only called after checking that count > 0
 	const mean = sum / point.value.count;
 
 	return { min: point.value.min ?? mean, max: point.value.max ?? mean, sum };

--- a/src/histogram.ts
+++ b/src/histogram.ts
@@ -18,76 +18,106 @@ import { SummaryValue } from "@dynatrace/metric-utils";
 import { DataPoint, Histogram } from "@opentelemetry/sdk-metrics-base";
 
 export function estimateHistogram(point: DataPoint<Histogram>): SummaryValue {
-	if (point.value.count === 0) {
-		return { count: 0, sum: 0, min: 0, max: 0 };
-	}
-
-	const { min, max } = getMinMax(point);
+	const { min, max, sum } = estimateOptionalProperties(point);
 
 	return {
 		count: point.value.count,
-		sum: point.value.sum,
+		sum,
 		max,
 		min
 	};
 }
 
-function getMinMax(point: DataPoint<Histogram>): { min: number; max: number } {
-	if (point.value.hasMinMax) {
-		return { min: point.value.min, max: point.value.max };
-	}
+function estimateSingleBucketHistogram(point: DataPoint<Histogram>): { min: number; max: number; sum: number } {
+	const sum = point.value.sum ?? 0;
+	const mean = sum / point.value.count;
 
-	return estimateHistMinMax(point);
+	return { min: point.value.min ?? mean, max: point.value.max ?? mean, sum };
 }
 
-// Expect to be called only with points that contain actual data (point.value.count > 0)
-function estimateHistMinMax(point: DataPoint<Histogram>): { min: number; max: number } {
-	const { counts, boundaries } = point.value.buckets;
-	const avg = point.value.sum / point.value.count;
-
-	if (boundaries.length === 0 && counts[0] > 0) {
-		return { min: avg, max: avg };
+function estimateOptionalProperties(point: DataPoint<Histogram>): { min: number; max: number; sum: number } {
+	// shortcut if min, max, and sum are provided
+	if (point.value.min != null && point.value.max != null && point.value.sum != null) {
+		return { min: point.value.min, max: point.value.max, sum: point.value.sum };
 	}
 
-	// Because we do not know the actual min and max, we estimate them based on the min and max non-empty bucket
-	let minCountIdx = -1;
-	let maxCountIdx = -1;
+	// Shortcut for 0 count histograms
+	if (point.value.count === 0) {
+		return { min: 0, max: 0, sum: 0 };
+	}
+
+	const counts = point.value.buckets.counts;
+	const boundaries = point.value.buckets.boundaries;
+
+	// a single-bucket histogram is a special case
+	if (counts.length === 1) {
+		return estimateSingleBucketHistogram(point);
+	}
+
+	// If any of min, max, sum is not provided in the data point,
+	// loop through the buckets to estimate them.
+	// All three values are estimated in order to avoid looping multiple times
+	// or complicating the loop with branches. After the loop, estimates
+	// will be overridden with any values provided by the data point.
+	let foundNonEmptyBucket = false;
+	let min = 0;
+	let max = 0;
+	let sum = 0;
+
+	// Because we do not know the actual min, max, or sum, we estimate them based on non-empty buckets
 	for (let i = 0; i < counts.length; i++) {
-		if (counts[i] > 0) {
-			if (minCountIdx === -1) {
-				minCountIdx = i;
+		// empty bucket.
+		if (counts[i] === 0) {
+			continue;
+		}
+
+		// range for bucket counts[i] is bounds[i-1] to bounds[i]
+
+		// min estimation.
+		if (!foundNonEmptyBucket) {
+			foundNonEmptyBucket = true;
+			if (i === 0) {
+				// if we're in the first bucket, the best estimate we can make for min is the upper bound
+				min = boundaries[i];
+			} else {
+				min = boundaries[i - 1];
 			}
-			maxCountIdx = i;
+		}
+
+		// max estimation
+		if (i === counts.length - 1) {
+			// if we're in the last bucket, the best estimate we can make for max is the lower bound
+			max = boundaries[i - 1];
+		} else {
+			max = boundaries[i];
+		}
+
+		// sum estimation
+		switch (i) {
+			case 0:
+				// in the first bucket, estimate sum using the upper bound
+				sum += counts[i] * boundaries[i];
+				break;
+			case counts.length - 1:
+				// in the last bucket, estimate sum using the lower bound
+				sum += counts[i] * boundaries[i - 1];
+				break;
+			default:
+				// in any other bucket, estimate sum using the bucket midpoint
+				sum += counts[i] * (boundaries[i] + boundaries[i - 1]) / 2;
+				break;
 		}
 	}
 
-	// no values found
-	if (minCountIdx === -1 || maxCountIdx === -1) {
-		return {
-			min: 0,
-			max: 0
-		};
-	}
-
-	let min: number;
-	let max: number;
-
-	// Use lower bound for min unless it is the first bucket which has no lower bound, then use upper
-	if (minCountIdx === 0) {
-		min = boundaries[minCountIdx];
-	} else {
-		min = boundaries[minCountIdx - 1];
-	}
-
-	// Use upper bound for max unless it is the last bucket which has no upper bound, then use lower
-	if (maxCountIdx === counts.length - 1) {
-		max = boundaries[maxCountIdx - 1];
-	} else {
-		max = boundaries[maxCountIdx];
-	}
+	// Override estimates with any values provided by the data point
+	min = point.value.min ?? min;
+	max = point.value.max ?? max;
+	sum = point.value.sum ?? sum;
 
 	// Set min to average when higher than average. This can happen when most values are lower than first boundary (falling in first bucket).
 	// Set max to average when lower than average. This can happen when most values are higher than last boundary (falling in last bucket).
+	// point.value.count will never be zero, as this is checked above.
+	const avg = sum / point.value.count;
 	if (min > avg) {
 		min = avg;
 	}
@@ -95,5 +125,5 @@ function estimateHistMinMax(point: DataPoint<Histogram>): { min: number; max: nu
 		max = avg;
 	}
 
-	return { min, max };
+	return { min, max, sum };
 }

--- a/tests/DynatraceMetricExporter.spec.ts
+++ b/tests/DynatraceMetricExporter.spec.ts
@@ -60,118 +60,6 @@ describe("DynatraceMetricExporter", () => {
 describe("MetricExporter.export", () => {
 	beforeEach(() => nock.cleanAll());
 
-	function getCounterResourceMetric(
-		name: string,
-		value: number,
-		attributes: MetricAttributes,
-		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
-	): ResourceMetrics {
-		// @ts-ignore this is guaranteed to be a ResourceMetric
-		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.COUNTER, DataPointType.SUM, true);
-	}
-
-	function getUpDownCounterResourceMetric(
-		name: string,
-		value: number,
-		attributes: MetricAttributes,
-		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
-	): ResourceMetrics {
-		// @ts-ignore this is guaranteed to be a ResourceMetric
-		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.UP_DOWN_COUNTER, DataPointType.SUM, false);
-	}
-
-	function getObservableGaugeResourceMetric(
-		name: string,
-		value: number,
-		attributes: MetricAttributes,
-		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
-	): ResourceMetrics {
-		// @ts-ignore this is guaranteed to be a ResourceMetric
-		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.OBSERVABLE_GAUGE, DataPointType.GAUGE);
-	}
-
-	function getResourceMetric(
-		name: string,
-		value: number,
-		attributes: MetricAttributes,
-		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA,
-		instrumentType: InstrumentType = InstrumentType.COUNTER,
-		dataPointType: DataPointType,
-		isMonotonic?: boolean
-	) {
-		return {
-			resource: new Resource({}),
-			scopeMetrics: [{
-				scope: {
-					name: "myscope"
-				},
-				metrics: [
-					{
-						aggregationTemporality: aggregationTemporality,
-						dataPointType: dataPointType,
-						isMonotonic: isMonotonic,
-						descriptor: {
-							description: "a data point",
-							name,
-							type: instrumentType,
-							unit: "",
-							valueType: ValueType.DOUBLE
-						},
-						dataPoints: [{
-							attributes,
-							endTime: [0, 0],
-							startTime: [0, 0],
-							value
-						}]
-					}
-				]
-			}]
-		};
-	}
-
-	function getHistogramResourceMetric(name: string, aggregationTemporality: AggregationTemporality, extrema?: { min: number; max: number }): ResourceMetrics {
-		return {
-			resource: new Resource({}),
-			scopeMetrics: [{
-				scope: {
-					name: "myscope"
-				},
-				metrics: [
-					{
-						aggregationTemporality: aggregationTemporality,
-						dataPointType: DataPointType.HISTOGRAM,
-						descriptor: {
-							description: "a histogram",
-							name: name,
-							type: InstrumentType.HISTOGRAM,
-							unit: "",
-							valueType: ValueType.DOUBLE
-						},
-						dataPoints: [
-							{
-								attributes: {
-									key: "value"
-								},
-								endTime: [0, 0],
-								startTime: [0, 0],
-								value: {
-									sum: 22.4,
-									min: extrema?.min,
-									max: extrema?.max,
-									buckets: {
-										boundaries: [1, 3, 5, 10],
-										counts: [3, 1, 2, 0, 1]
-									},
-									count: 7
-								}
-							}
-						]
-					}
-				]
-			}]
-		};
-	}
-
 	test("should export metrics and return a success message", (done) => {
 		const target_host = "https://example.com:8080";
 		const target_path = "/metrics";
@@ -821,4 +709,115 @@ describe("MetricExporter.export", () => {
 			);
 	});
 
+	function getCounterResourceMetric(
+		name: string,
+		value: number,
+		attributes: MetricAttributes,
+		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
+	): ResourceMetrics {
+		// @ts-ignore this is guaranteed to be a ResourceMetric
+		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.COUNTER, DataPointType.SUM, true);
+	}
+
+	function getUpDownCounterResourceMetric(
+		name: string,
+		value: number,
+		attributes: MetricAttributes,
+		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
+	): ResourceMetrics {
+		// @ts-ignore this is guaranteed to be a ResourceMetric
+		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.UP_DOWN_COUNTER, DataPointType.SUM, false);
+	}
+
+	function getObservableGaugeResourceMetric(
+		name: string,
+		value: number,
+		attributes: MetricAttributes,
+		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
+	): ResourceMetrics {
+		// @ts-ignore this is guaranteed to be a ResourceMetric
+		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.OBSERVABLE_GAUGE, DataPointType.GAUGE);
+	}
+
+	function getResourceMetric(
+		name: string,
+		value: number,
+		attributes: MetricAttributes,
+		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA,
+		instrumentType: InstrumentType = InstrumentType.COUNTER,
+		dataPointType: DataPointType,
+		isMonotonic?: boolean
+	) {
+		return {
+			resource: new Resource({}),
+			scopeMetrics: [{
+				scope: {
+					name: "myscope"
+				},
+				metrics: [
+					{
+						aggregationTemporality: aggregationTemporality,
+						dataPointType: dataPointType,
+						isMonotonic: isMonotonic,
+						descriptor: {
+							description: "a data point",
+							name,
+							type: instrumentType,
+							unit: "",
+							valueType: ValueType.DOUBLE
+						},
+						dataPoints: [{
+							attributes,
+							endTime: [0, 0],
+							startTime: [0, 0],
+							value
+						}]
+					}
+				]
+			}]
+		};
+	}
+
+	function getHistogramResourceMetric(name: string, aggregationTemporality: AggregationTemporality, extrema?: { min: number; max: number }): ResourceMetrics {
+		return {
+			resource: new Resource({}),
+			scopeMetrics: [{
+				scope: {
+					name: "myscope"
+				},
+				metrics: [
+					{
+						aggregationTemporality: aggregationTemporality,
+						dataPointType: DataPointType.HISTOGRAM,
+						descriptor: {
+							description: "a histogram",
+							name: name,
+							type: InstrumentType.HISTOGRAM,
+							unit: "",
+							valueType: ValueType.DOUBLE
+						},
+						dataPoints: [
+							{
+								attributes: {
+									key: "value"
+								},
+								endTime: [0, 0],
+								startTime: [0, 0],
+								value: {
+									sum: 22.4,
+									min: extrema?.min,
+									max: extrema?.max,
+									buckets: {
+										boundaries: [1, 3, 5, 10],
+										counts: [3, 1, 2, 0, 1]
+									},
+									count: 7
+								}
+							}
+						]
+					}
+				]
+			}]
+		};
+	}
 });

--- a/tests/DynatraceMetricExporter.spec.ts
+++ b/tests/DynatraceMetricExporter.spec.ts
@@ -66,7 +66,7 @@ describe("MetricExporter.export", () => {
 		attributes: MetricAttributes,
 		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
 	): ResourceMetrics {
-		// @ts-ignore bla
+		// @ts-ignore this is guaranteed to be a ResourceMetric
 		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.COUNTER, DataPointType.SUM, true);
 	}
 
@@ -76,7 +76,7 @@ describe("MetricExporter.export", () => {
 		attributes: MetricAttributes,
 		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
 	): ResourceMetrics {
-		// @ts-ignore bla
+		// @ts-ignore this is guaranteed to be a ResourceMetric
 		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.UP_DOWN_COUNTER, DataPointType.SUM, false);
 	}
 
@@ -86,7 +86,7 @@ describe("MetricExporter.export", () => {
 		attributes: MetricAttributes,
 		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
 	): ResourceMetrics {
-		// @ts-ignore bla
+		// @ts-ignore this is guaranteed to be a ResourceMetric
 		return getResourceMetric(name, value, attributes, aggregationTemporality, InstrumentType.OBSERVABLE_GAUGE, DataPointType.GAUGE);
 	}
 


### PR DESCRIPTION
This PR updates the Metrics SDK to `0.31.0`. Since optional sums were introduced in that version, this update introduces the same Histogram estimation that we use in the collector exporter.

Closes #29
Closes #30 
Closes #31 
Closes #32 