### PR TITLE
Update metrics SDK to 0.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This exporter allows exporting metrics created using the [OpenTelemetry SDK for JavaScript](https://github.com/open-telemetry/opentelemetry-js)
 directly to [Dynatrace](https://www.dynatrace.com).
 
-It was built against OpenTelemetry SDK version `0.31.0`.
+It was built against OpenTelemetry SDK version `0.32.0`.
 
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in
 the [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-metrics).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dynatrace/opentelemetry-exporter-metrics",
   "description": "OpenTelemetry metrics exporter for Dynatrace",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "Dynatrace",
   "license": "Apache-2",
   "publishConfig": {
@@ -31,10 +31,10 @@
   "homepage": "https://github.com/dynatrace-oss/opentelemetry-metrics-js#readme",
   "dependencies": {
     "@dynatrace/metric-utils": "^0.2.0",
-    "@opentelemetry/api-metrics": "^0.31.0",
-    "@opentelemetry/core": "~1.5.0",
-    "@opentelemetry/resources": "~1.5.0",
-    "@opentelemetry/sdk-metrics-base": "^0.31.0"
+    "@opentelemetry/api-metrics": "^0.32.0",
+    "@opentelemetry/core": "~1.6.0",
+    "@opentelemetry/resources": "~1.6.0",
+    "@opentelemetry/sdk-metrics": "^0.32.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"
@@ -51,7 +51,7 @@
     "eslint-plugin-deprecation": "^1.2.1",
     "eslint-plugin-header": "^3.1.1",
     "jest": "^27.0.6",
-    "markdownlint-cli": "^0.27.1",
+    "markdownlint-cli": "^0.32.2",
     "mock-fs": "^5.0.0",
     "nock": "^13.1.3",
     "rimraf": "^3.0.2",

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -2,7 +2,7 @@
 
 const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
 const { Resource } = require('@opentelemetry/resources');
-const { MeterProvider } = require('@opentelemetry/sdk-metrics-base');
+const { MeterProvider } = require('@opentelemetry/sdk-metrics');
 const { configureDynatraceMetricExport } = require('..');
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)

--- a/src/DynatraceMetricExport.ts
+++ b/src/DynatraceMetricExport.ts
@@ -15,7 +15,7 @@
 */
 
 import { ExporterConfig, ReaderConfig } from "./types";
-import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics-base";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
 import { DynatraceMetricExporter } from "./DynatraceMetricExporter";
 
 /**

--- a/src/DynatraceMetricExporter.ts
+++ b/src/DynatraceMetricExporter.ts
@@ -27,7 +27,7 @@ import {
 	PushMetricExporter,
 	ResourceMetrics,
 	SumMetricData
-} from "@opentelemetry/sdk-metrics-base";
+} from "@opentelemetry/sdk-metrics";
 import * as http from "http";
 import * as https from "https";
 import * as url from "url";

--- a/src/histogram.ts
+++ b/src/histogram.ts
@@ -15,7 +15,7 @@
 */
 
 import { SummaryValue } from "@dynatrace/metric-utils";
-import { DataPoint, Histogram } from "@opentelemetry/sdk-metrics-base";
+import { DataPoint, Histogram } from "@opentelemetry/sdk-metrics";
 
 export function estimateHistogram(point: DataPoint<Histogram>): SummaryValue {
 	const { min, max, sum } = estimateOptionalProperties(point);

--- a/tests/DynatraceMetricExporter.spec.ts
+++ b/tests/DynatraceMetricExporter.spec.ts
@@ -19,7 +19,7 @@ import * as nock from "nock";
 import { MetricAttributes, ValueType } from "@opentelemetry/api-metrics";
 import { ExportResult, ExportResultCode } from "@opentelemetry/core";
 import { Resource } from "@opentelemetry/resources";
-import { AggregationTemporality, DataPointType, InstrumentType, ResourceMetrics } from "@opentelemetry/sdk-metrics-base";
+import { AggregationTemporality, DataPointType, InstrumentType, ResourceMetrics } from "@opentelemetry/sdk-metrics";
 
 
 describe("DynatraceMetricExporter", () => {


### PR DESCRIPTION
This PR updates the Metrics SDK to 0.32.0. `@opentelemetry/sdk-metrics-base` was renamed `@opentelemetry/sdk-metrics`