### PR TITLE
Change README.md so that the example matches the one from `samples/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)
 
 // Configure a MeterProvider
 const provider = new MeterProvider({
-  resource: new Resource({ 'service.name': 'opentelemetry-metrics-sample-dynatrace' })
+  resource: new Resource({
+    'service.name': 'opentelemetry-metrics-sample-dynatrace'
+  })
 });
 
 const reader = configureDynatraceMetricExport(
   // exporter configuration
   {
-    prefix: 'sample', // optional
+    prefix: 'sample' // optional
 
     // If no OneAgent is available locally, export directly to the Dynatrace server:
     // url: 'https://myenv123.live.dynatrace.com/api/v2/metrics/ingest',

--- a/README.md
+++ b/README.md
@@ -52,47 +52,60 @@ npm install @opentelemetry/api
 The Dynatrace exporter is added and set-up like this:
 
 ```js
-const { configureDynatraceMetricExport } = require('@dynatrace/opentelemetry-exporter-metrics');
+'use strict';
+
 const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api');
 const { Resource } = require('@opentelemetry/resources');
 const { MeterProvider } = require('@opentelemetry/sdk-metrics');
+const { configureDynatraceMetricExport } = require('@dynatrace/opentelemetry-exporter-metrics');
 
-// optional: set up logging for OpenTelemetry
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL);
 
-// configure the export to Dynatrace
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)
+
+// Configure a MeterProvider
+const provider = new MeterProvider({
+  resource: new Resource({ 'service.name': 'opentelemetry-metrics-sample-dynatrace' })
+});
+
 const reader = configureDynatraceMetricExport(
   // exporter configuration
   {
-    prefix: 'my_prefix', // optional
-    defaultDimensions: [   // optional
-      { key: 'default-dim', value: 'default-dim-value' },
-    ],
+    prefix: 'sample', // optional
 
-    // If no OneAgent is available locally, set up url and token and export
-    // directly to the Dynatrace server:
+    // If no OneAgent is available locally, export directly to the Dynatrace server:
     // url: 'https://myenv123.live.dynatrace.com/api/v2/metrics/ingest',
     // apiToken: '<load API token from secure location such as env or config file>'
   },
   // metric reader configuration
   {
-    exportIntervalMillis: 5000,
+    exportIntervalMillis: 5000
   }
 );
 
-const provider = new MeterProvider({
-  resource: new Resource({'service.name': 'your-service-name'})
-});
-
 provider.addMetricReader(reader);
+
 const meter = provider.getMeter('opentelemetry-metrics-sample-dynatrace');
 
 // Your SDK should be set up correctly now. You can create instruments...
 const requestCounter = meter.createCounter('requests', {
-  description: 'Example of a Counter',
+  description: 'Example of a Counter'
 });
+
+const upDownCounter = meter.createUpDownCounter('test_up_down_counter', {
+  description: 'Example of a UpDownCounter'
+});
+
+// ...set up attributes...
+const attributes = {
+  pid: process.pid.toString(),
+  environment: 'staging'
+};
+
 // ... and start recording metrics:
-requestCounter.add(2);
+setInterval(() => {
+  requestCounter.add(Math.round(Math.random() * 1000), attributes);
+  upDownCounter.add(Math.random() > 0.5 ? 1 : -1, attributes);
+}, 1000);
 ```
 
 Metrics are exported periodically, depending on the value of

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ const { MeterProvider } = require('@opentelemetry/sdk-metrics');
 const { configureDynatraceMetricExport } = require('@dynatrace/opentelemetry-exporter-metrics');
 
 
+// optional: set up logging for OpenTelemetry
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)
 
 // Configure a MeterProvider
@@ -72,8 +73,10 @@ const provider = new MeterProvider({
 const reader = configureDynatraceMetricExport(
   // exporter configuration
   {
-    prefix: 'sample' // optional
-
+    prefix: 'sample', // optional
+    defaultDimensions: [ // optional
+      { key: 'default-dim', value: 'default-dim-value' },
+    ],
     // If no OneAgent is available locally, export directly to the Dynatrace server:
     // url: 'https://myenv123.live.dynatrace.com/api/v2/metrics/ingest',
     // apiToken: '<load API token from secure location such as env or config file>'

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -9,13 +9,15 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)
 
 // Configure a MeterProvider
 const provider = new MeterProvider({
-  resource: new Resource({ 'service.name': 'opentelemetry-metrics-sample-dynatrace' })
+  resource: new Resource({
+    'service.name': 'opentelemetry-metrics-sample-dynatrace'
+  })
 });
 
 const reader = configureDynatraceMetricExport(
   // exporter configuration
   {
-    prefix: 'sample', // optional
+    prefix: 'sample' // optional
 
     // If no OneAgent is available locally, export directly to the Dynatrace server:
     // url: 'https://myenv123.live.dynatrace.com/api/v2/metrics/ingest',

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -5,6 +5,7 @@ const { Resource } = require('@opentelemetry/resources');
 const { MeterProvider } = require('@opentelemetry/sdk-metrics');
 const { configureDynatraceMetricExport } = require('..');
 
+// optional: set up logging for OpenTelemetry
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)
 
 // Configure a MeterProvider
@@ -17,8 +18,10 @@ const provider = new MeterProvider({
 const reader = configureDynatraceMetricExport(
   // exporter configuration
   {
-    prefix: 'sample' // optional
-
+    prefix: 'sample', // optional
+    defaultDimensions: [ // optional
+      { key: 'default-dim', value: 'default-dim-value' },
+    ],
     // If no OneAgent is available locally, export directly to the Dynatrace server:
     // url: 'https://myenv123.live.dynatrace.com/api/v2/metrics/ingest',
     // apiToken: '<load API token from secure location such as env or config file>'

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -7,8 +7,13 @@ const { configureDynatraceMetricExport } = require('..');
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ALL)
 
+// Configure a MeterProvider
+const provider = new MeterProvider({
+  resource: new Resource({ 'service.name': 'opentelemetry-metrics-sample-dynatrace' })
+});
+
 const reader = configureDynatraceMetricExport(
-  // ExporterConfig
+  // exporter configuration
   {
     prefix: 'sample', // optional
 
@@ -16,16 +21,17 @@ const reader = configureDynatraceMetricExport(
     // url: 'https://myenv123.live.dynatrace.com/api/v2/metrics/ingest',
     // apiToken: '<load API token from secure location such as env or config file>'
   },
-  // ReaderConfig
+  // metric reader configuration
   {
     exportIntervalMillis: 5000
   }
 );
 
-const provider = new MeterProvider({ resource: new Resource({ 'service.name': 'opentelemetry-metrics-sample-dynatrace' }) });
 provider.addMetricReader(reader);
+
 const meter = provider.getMeter('opentelemetry-metrics-sample-dynatrace');
 
+// Your SDK should be set up correctly now. You can create instruments...
 const requestCounter = meter.createCounter('requests', {
   description: 'Example of a Counter'
 });
@@ -33,11 +39,14 @@ const requestCounter = meter.createCounter('requests', {
 const upDownCounter = meter.createUpDownCounter('test_up_down_counter', {
   description: 'Example of a UpDownCounter'
 });
+
+// ...set up attributes...
 const attributes = {
   pid: process.pid.toString(),
   environment: 'staging'
 };
 
+// ... and start recording metrics:
 setInterval(() => {
   requestCounter.add(Math.round(Math.random() * 1000), attributes);
   upDownCounter.add(Math.random() > 0.5 ? 1 : -1, attributes);


### PR DESCRIPTION
Previously the example would would not export due to terminating before the first export. This PR takes the example from the `sampels/` directory and uses it in the `README.md`.