### PR TITLE
chore: update exporter to API 1.3.0/SDK 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
 # Dynatrace OpenTelemetry Metrics Exporter for JavaScript
 
-> This exporter is based on the OpenTelemetry Metrics SDK for JavaScript,
-> which is currently in an RC state and neither considered stable nor
-> complete as of this writing.
-> As such, this exporter is not intended for production use until the
-> underlying OpenTelemetry Metrics API and SDK are stable.
-> See [open-telemetry/opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js)
-> for the current state of the OpenTelemetry SDK for JavaScript.
+> This exporter is currently in RC state and therefore
+> not intended for production use.
 
 This exporter allows exporting metrics created using the [OpenTelemetry SDK for JavaScript](https://github.com/open-telemetry/opentelemetry-js)
 directly to [Dynatrace](https://www.dynatrace.com).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This exporter allows exporting metrics created using the [OpenTelemetry SDK for JavaScript](https://github.com/open-telemetry/opentelemetry-js)
 directly to [Dynatrace](https://www.dynatrace.com).
 
-It was built against OpenTelemetry SDK version `0.33.0`.
+It was built against OpenTelemetry SDK version `1.8.0`.
 
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in
 the [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-metrics).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dynatrace/opentelemetry-exporter-metrics",
   "description": "OpenTelemetry metrics exporter for Dynatrace",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": "Dynatrace",
   "license": "Apache-2",
   "publishConfig": {
@@ -31,16 +31,15 @@
   "homepage": "https://github.com/dynatrace-oss/opentelemetry-metrics-js#readme",
   "dependencies": {
     "@dynatrace/metric-utils": "^0.2.0",
-    "@opentelemetry/api-metrics": "^0.33.0",
-    "@opentelemetry/core": "~1.7.0",
-    "@opentelemetry/resources": "~1.7.0",
-    "@opentelemetry/sdk-metrics": "^0.33.0"
+    "@opentelemetry/core": "^1.8.0",
+    "@opentelemetry/resources": "^1.8.0",
+    "@opentelemetry/sdk-metrics": "^1.8.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
+    "@opentelemetry/api": "^1.3.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/api": "^1.3.0",
     "@types/jest": "^27.0.2",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^16.3.2",

--- a/tests/DynatraceMetricExporter.spec.ts
+++ b/tests/DynatraceMetricExporter.spec.ts
@@ -16,7 +16,7 @@
 
 import { DynatraceMetricExporter } from "../src/DynatraceMetricExporter";
 import * as nock from "nock";
-import { MetricAttributes, ValueType } from "@opentelemetry/api-metrics";
+import { MetricAttributes, ValueType } from "@opentelemetry/api";
 import { ExportResult, ExportResultCode } from "@opentelemetry/core";
 import { Resource } from "@opentelemetry/resources";
 import { AggregationTemporality, DataPointType, InstrumentType, ResourceMetrics } from "@opentelemetry/sdk-metrics";


### PR DESCRIPTION
This PR updates `@opentelemetry/api` to `1.3.0` and `@opentelemetry/sdk-metrics` to `1.8.0`.
Removes `@opentelemetry/api-metrics` as the package has been deprecated and merged into `@opentelemetry/api`.