### PR TITLE
Update API to 1.4.0 and SDK to 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This exporter allows exporting metrics created using the [OpenTelemetry SDK for JavaScript](https://github.com/open-telemetry/opentelemetry-js)
 directly to [Dynatrace](https://www.dynatrace.com).
 
-It was built against OpenTelemetry SDK version `1.8.0`.
+It was built against OpenTelemetry SDK version `1.9.1`.
 
 More information on exporting OpenTelemetry metrics to Dynatrace can be found in
 the [Dynatrace documentation](https://www.dynatrace.com/support/help/shortlink/opentelemetry-metrics).

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
   "homepage": "https://github.com/dynatrace-oss/opentelemetry-metrics-js#readme",
   "dependencies": {
     "@dynatrace/metric-utils": "^0.2.0",
-    "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-metrics": "^1.8.0"
+    "@opentelemetry/core": "^1.9.1",
+    "@opentelemetry/resources": "^1.9.1",
+    "@opentelemetry/sdk-metrics": "^1.9.1"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.3.0"
+    "@opentelemetry/api": "^1.4.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/api": "^1.4.0",
     "@types/jest": "^27.0.2",
     "@types/mock-fs": "^4.13.1",
     "@types/node": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dynatrace/opentelemetry-exporter-metrics",
   "description": "OpenTelemetry metrics exporter for Dynatrace",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": "Dynatrace",
   "license": "Apache-2",
   "publishConfig": {

--- a/tests/DynatraceMetricExporter.spec.ts
+++ b/tests/DynatraceMetricExporter.spec.ts
@@ -16,7 +16,7 @@
 
 import { DynatraceMetricExporter } from "../src/DynatraceMetricExporter";
 import * as nock from "nock";
-import { MetricAttributes, ValueType } from "@opentelemetry/api";
+import { Attributes, ValueType } from "@opentelemetry/api";
 import { ExportResult, ExportResultCode } from "@opentelemetry/core";
 import { Resource } from "@opentelemetry/resources";
 import { AggregationTemporality, DataPointType, InstrumentType, ResourceMetrics } from "@opentelemetry/sdk-metrics";
@@ -712,7 +712,7 @@ describe("MetricExporter.export", () => {
 	function getCounterResourceMetric(
 		name: string,
 		value: number,
-		attributes: MetricAttributes,
+		attributes: Attributes,
 		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
 	): ResourceMetrics {
 		// @ts-ignore this is guaranteed to be a ResourceMetric
@@ -722,7 +722,7 @@ describe("MetricExporter.export", () => {
 	function getUpDownCounterResourceMetric(
 		name: string,
 		value: number,
-		attributes: MetricAttributes,
+		attributes: Attributes,
 		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
 	): ResourceMetrics {
 		// @ts-ignore this is guaranteed to be a ResourceMetric
@@ -732,7 +732,7 @@ describe("MetricExporter.export", () => {
 	function getObservableGaugeResourceMetric(
 		name: string,
 		value: number,
-		attributes: MetricAttributes,
+		attributes: Attributes,
 		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA
 	): ResourceMetrics {
 		// @ts-ignore this is guaranteed to be a ResourceMetric
@@ -742,7 +742,7 @@ describe("MetricExporter.export", () => {
 	function getResourceMetric(
 		name: string,
 		value: number,
-		attributes: MetricAttributes,
+		attributes: Attributes,
 		aggregationTemporality: AggregationTemporality = AggregationTemporality.DELTA,
 		instrumentType: InstrumentType = InstrumentType.COUNTER,
 		dataPointType: DataPointType,


### PR DESCRIPTION
`MetricAttributes` has been deprecated in favor of `Attributes`, so that change is reflected here.