### PR TITLE
ci: allow `workflow_dispatch` event trigger

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   SUPPORTED_VERSIONS: '[14,16,18]'


### PR DESCRIPTION
Allows us to dispatch a workflow run when a new version of OTel JS is out. :slightly_smiling_face: